### PR TITLE
simplify refresh_csrf_token implementation

### DIFF
--- a/ensta/lib/Commons.py
+++ b/ensta/lib/Commons.py
@@ -16,20 +16,7 @@ def update_app_id(self) -> None:
 
 def refresh_csrf_token(self) -> None:
     self.csrf_token = "".join(random.choices(string.ascii_letters + string.digits, k=32))
-
-    cookie_jar: RequestsCookieJar = self.request_session.cookies
-    cookies = list(cookie_jar.items())
-    cookie_jar.clear()
-    final_cookies = {}
-
-    for key, value in cookies:
-        final_cookies[key] = value
-
-    final_cookies["csrftoken"] = self.csrf_token
-
-    for key in final_cookies:
-        cookie_jar.set(key, final_cookies[key])
-
+    self.request_session.cookies.set("csrftoken", self.csrf_token)
 
 def update_session(self) -> None:
     self.request_session = requests.Session()


### PR DESCRIPTION
existing code redundantly reads the cookiejar clears it, duplicates all the existing cookies into a new dict and then sets the old cookiejar when `self.request_session.cookies.set` can be used directly. 

cc @diezo 