### PR TITLE
Fix fb uploader

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,4 +16,4 @@ ntplib = "*"
 python_version = "3.10"
 
 [scripts]
-test = "python -m unittest"
+test = "python -m unittest discover -s test_ensta/ -t ."

--- a/ensta/Direct.py
+++ b/ensta/Direct.py
@@ -5,9 +5,8 @@ import string
 import random
 from .lib.Exceptions import FileTypeError, NetworkError
 from json import JSONDecodeError
-import time
 from pathlib import Path
-
+from ensta.Utils import time_id
 
 class Direct:
 
@@ -78,7 +77,7 @@ class Direct:
         with open(media_path, "rb") as file:
             media_data: bytes = file.read()
 
-        upload_name: str = f"{str(int(time.time()) * 1000)}_0_{random.randint(1000000000, 9999999999)}"
+        upload_name: str = f"{time_id()}_0_{random.randint(1000000000, 9999999999)}"
         media_length: str = str(len(media_data))
 
         response: Response = self.session.post(

--- a/ensta/Direct.py
+++ b/ensta/Direct.py
@@ -6,7 +6,8 @@ import random
 from .lib.Exceptions import FileTypeError, NetworkError
 from json import JSONDecodeError
 from pathlib import Path
-from ensta.Utils import time_id
+from ensta.Utils import fb_uploader
+
 
 class Direct:
 
@@ -56,9 +57,11 @@ class Direct:
             }
         )
 
-        try: return response.json().get("status", "") == "ok"
+        try:
+            return response.json().get("status", "") == "ok"
 
-        except JSONDecodeError: return False
+        except JSONDecodeError:
+            return False
 
     def fb_upload_image(self, media_path: str) -> int:
         """
@@ -77,7 +80,7 @@ class Direct:
         with open(media_path, "rb") as file:
             media_data: bytes = file.read()
 
-        upload_name: str = f"{time_id()}_0_{random.randint(1000000000, 9999999999)}"
+        upload_name: str = fb_uploader()
         media_length: str = str(len(media_data))
 
         response: Response = self.session.post(
@@ -95,7 +98,8 @@ class Direct:
             data=media_data
         )
 
-        try: return response.json().get("media_id")
+        try:
+            return response.json().get("media_id")
 
         except JSONDecodeError:
             raise NetworkError(
@@ -134,6 +138,8 @@ class Direct:
             }
         )
 
-        try: return response.json().get("status", "") == "ok"
+        try:
+            return response.json().get("status", "") == "ok"
 
-        except JSONDecodeError: return False
+        except JSONDecodeError:
+            return False

--- a/ensta/Mobile.py
+++ b/ensta/Mobile.py
@@ -4,13 +4,12 @@ from .lib.Exceptions import AuthenticationError, FileTypeError, NetworkError
 from uuid import uuid4
 from json import  JSONDecodeError
 from pathlib import Path
-import random
 import string
 import json
 from .parser.ProfileParser import parse_profile
 from .structures import Profile
 from .Direct import Direct
-from ensta.Utils import time_id
+from ensta.Utils import time_id, fb_uploader
 
 class Mobile:
 
@@ -143,7 +142,7 @@ class Mobile:
             )
 
         upload_id = arg_upload_id if arg_upload_id is not None else time_id()
-        upload_name = f"{upload_id}_0_{random.randint(1000000000, 9999999999)}"
+        upload_name = fb_uploader(upload_id)
 
         rupload_params = {
             "retry_context": "{\"num_step_auto_retry\": 0, \"num_reupload\": 0, \"num_step_manual_retry\": 0}",

--- a/ensta/Mobile.py
+++ b/ensta/Mobile.py
@@ -4,14 +4,13 @@ from .lib.Exceptions import AuthenticationError, FileTypeError, NetworkError
 from uuid import uuid4
 from json import  JSONDecodeError
 from pathlib import Path
-import time
 import random
 import string
 import json
 from .parser.ProfileParser import parse_profile
 from .structures import Profile
 from .Direct import Direct
-
+from ensta.Utils import time_id
 
 class Mobile:
 
@@ -143,7 +142,7 @@ class Mobile:
                 "Only jpg and jpeg image types are allowed to upload."
             )
 
-        upload_id = arg_upload_id if arg_upload_id is not None else str(int(time.time()) * 1000)
+        upload_id = arg_upload_id if arg_upload_id is not None else time_id()
         upload_name = f"{upload_id}_0_{random.randint(1000000000, 9999999999)}"
 
         rupload_params = {

--- a/ensta/SessionHost.py
+++ b/ensta/SessionHost.py
@@ -23,7 +23,7 @@ from .lib import (
     ConversionError,
     FileTypeError
 )
-from ensta.Utils import time_id
+from ensta.Utils import time_id, fb_uploader
 
 USERNAME, UID = 0, 1
 
@@ -834,7 +834,7 @@ class SessionHost:
 
         upload_id = arg_upload_id if arg_upload_id is not None else time_id()
         waterfall_id = str(uuid4())
-        upload_name = f"{upload_id}_0_{random.randint(1000000000, 9999999999)}"
+        upload_name = fb_uploader(upload_id)
 
         rupload_params = {
             "retry_context": "{\"num_step_auto_retry\": 0, \"num_reupload\": 0, \"num_step_manual_retry\": 0}",
@@ -886,7 +886,7 @@ class SessionHost:
         waterfall_id = str(uuid4())
 
         upload_id = arg_upload_id if arg_upload_id is not None else time_id()
-        upload_name = f"{upload_id}_0_{random.randint(1000000000, 9999999999)}"
+        upload_name = fb_uploader(upload_id)
 
         rupload_params = {
             "is_clips_video": "1",

--- a/ensta/SessionHost.py
+++ b/ensta/SessionHost.py
@@ -1,4 +1,3 @@
-import time
 import json
 import random
 import string
@@ -24,6 +23,7 @@ from .lib import (
     ConversionError,
     FileTypeError
 )
+from ensta.Utils import time_id
 
 USERNAME, UID = 0, 1
 
@@ -832,7 +832,7 @@ class SessionHost:
             "Only jpg and jpeg image types are allowed to post."
         )
 
-        upload_id = arg_upload_id if arg_upload_id is not None else str(int(time.time()) * 1000)
+        upload_id = arg_upload_id if arg_upload_id is not None else time_id()
         waterfall_id = str(uuid4())
         upload_name = f"{upload_id}_0_{random.randint(1000000000, 9999999999)}"
 
@@ -885,7 +885,7 @@ class SessionHost:
         path: Path = Path(path)
         waterfall_id = str(uuid4())
 
-        upload_id = arg_upload_id if arg_upload_id is not None else str(int(time.time()) * 1000)
+        upload_id = arg_upload_id if arg_upload_id is not None else time_id()
         upload_name = f"{upload_id}_0_{random.randint(1000000000, 9999999999)}"
 
         rupload_params = {
@@ -1072,7 +1072,7 @@ class SessionHost:
             "archive_only": archive_only,
             "caption": caption,
             "children_metadata": [{"upload_id": upload_id} for upload_id in upload_ids],
-            "client_sidecar_id": str(int(time.time()) * 1000),
+            "client_sidecar_id": time_id(),
             "disable_comments": "1" if disable_comments else "0",
             "like_and_view_counts_disabled": "1" if like_and_view_counts_disabled else "0",
             "source_type": "library"
@@ -1116,7 +1116,7 @@ class SessionHost:
         :return: ReelUpload
         """
 
-        upload_id = str(int(time.time()) * 1000)
+        upload_id = time_id()
 
         video_success, video_duration, video_width, video_height = self.__upload_video(video_path, upload_id)
 

--- a/ensta/Utils.py
+++ b/ensta/Utils.py
@@ -1,0 +1,5 @@
+import time
+
+
+def time_id() -> str:
+    return str(int(time.time() * 1000))

--- a/ensta/Utils.py
+++ b/ensta/Utils.py
@@ -3,3 +3,8 @@ import time
 
 def time_id() -> str:
     return str(int(time.time() * 1000))
+
+
+def fb_uploader(id: str | None) -> str:
+    id = id if id else time_id()
+    return f'fb_uploader_{id}'

--- a/ensta/__init__.py
+++ b/ensta/__init__.py
@@ -7,3 +7,4 @@ from ensta.Authentication import new_session_id
 from ensta.Direct import Direct
 from ensta.Mobile import Mobile
 from ensta.Credentials import Credentials
+from ensta.Utils import time_id, fb_uploader

--- a/test_ensta/test_utils.py
+++ b/test_ensta/test_utils.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+import time
+from ensta.Utils import time_id
+
+
+class TimeIdTest(TestCase):
+
+    def test_time_id(self):
+        total = 10
+        ids = set()
+        for _ in range(total):
+            ids.add(time_id())
+            time.sleep(0.001)
+        self.assertEqual(len(ids), total)


### PR DESCRIPTION
The old way always generate with 000 at the end
```python
[eleandro@fedora ~]$ python
Python 3.11.7 (main, Dec 18 2023, 00:00:00) [GCC 13.2.1 20231011 (Red Hat 13.2.1-4)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import time
>>> str(int(time.time()) * 1000)
'1707504381000'
>>> str(int(time.time()) * 1000)
'1707504382000'
>>> str(int(time.time()) * 1000)
'1707504382000'
>>> str(int(time.time()) * 1000)
'1707504383000'
>>> str(int(time.time()) * 1000)
'1707504383000'
>>> 
```